### PR TITLE
update for rubocop 0.88+

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -3,7 +3,7 @@ AllCops:
   CacheRootDirectory: '.git'
   Exclude:
     - coverage/**/*
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
 
 
 ### Lint
@@ -11,12 +11,6 @@ AllCops:
 Lint/NestedMethodDefinition:
   Exclude:
     - api/sinatra/**/*
-
-Lint/RaiseException:
-  Enabled: true
-
-Lint/StructNewOverride:
-  Enabled: true
 
 ### Metrics
 
@@ -44,13 +38,6 @@ Metrics/ClassLength:
 Metrics/CyclomaticComplexity:
   Severity: refactor
 
-Metrics/LineLength:
-  Max: 119
-  Exclude:
-    - Guardfile
-    - Gemfile
-  IgnoreCopDirectives: true
-
 Layout/LineLength:
   Max: 119
   Exclude:
@@ -59,7 +46,6 @@ Layout/LineLength:
   IgnoreCopDirectives: true
 
 Metrics/MethodLength:
-  Enabled: true
   CountComments: false # count full line comments?
   Max: 10
   Severity: refactor
@@ -75,10 +61,6 @@ Metrics/ModuleLength:
 ### Style / Layout
 
 #### Hash
-Style/AlignHash:
-  EnforcedColonStyle: table
-  EnforcedHashRocketStyle: table
-
 Layout/HashAlignment:
   EnforcedColonStyle: table
   EnforcedHashRocketStyle: table
@@ -86,19 +68,11 @@ Layout/HashAlignment:
 Style/HashSyntax:
   EnforcedStyle: ruby19_no_mixed_keys
 
-Style/HashEachMethods:
-  Enabled: true
-
 Style/HashTransformKeys:
   Enabled: false
 
 Style/HashTransformValues:
   Enabled: false
-
-#### MultilineOperation
-Style/MultilineOperationIndentation:
-  Description: Checks indentation of binary operations that span more than one line.
-  EnforcedStyle: indented
 
 Layout/MultilineOperationIndentation:
   Description: Checks indentation of binary operations that span more than one line.
@@ -112,6 +86,8 @@ Style/DoubleNegation:
   Enabled: false
 
 Style/ExponentialNotation:
+  # https://docs.rubocop.org/rubocop/cops_style.html#styleexponentialnotation
+  Enabled: true
   EnforcedStyle: engineering
 
 Style/NumericLiterals:
@@ -130,9 +106,6 @@ Style/RegexpLiteral:
 
 Style/SignalException:
   EnforcedStyle: only_raise
-
-Layout/SpaceAroundMethodCallOperator:
-  Enabled: true
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes
@@ -167,3 +140,45 @@ RSpec/NamedSubject:
 
 RSpec/NestedGroups:
   Enabled: false
+
+## new between 0.79 and 0.88
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: true
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: true
+Lint/DuplicateElsifCondition:
+  Enabled: true
+Lint/MixedRegexpCaptureTypes:
+  Enabled: true
+Lint/RaiseException:
+  Enabled: true
+Lint/StructNewOverride:
+  Enabled: true
+Style/AccessorGrouping:
+  Enabled: true
+Style/ArrayCoercion:
+  Enabled: true
+Style/BisectedAttrAccessor:
+  Enabled: true
+Style/CaseLikeIf:
+  Enabled: true
+Style/HashAsLastArrayItem:
+  Enabled: true
+Style/HashEachMethods:
+  Enabled: true
+Style/HashLikeCase:
+  Enabled: true
+Style/RedundantAssignment:
+  Enabled: true
+Style/RedundantFetchBlock:
+  Enabled: true
+Style/RedundantFileExtensionInRequire:
+  Enabled: true
+Style/RedundantRegexpCharacterClass:
+  Enabled: true
+Style/RedundantRegexpEscape:
+  Enabled: true
+Style/SlicingWithRange:
+  Enabled: true

--- a/lib/rt_rubocop_defaults/version.rb
+++ b/lib/rt_rubocop_defaults/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RTRuboCopDefaults
-  VERSION = "1.2.5"
+  VERSION = "1.3.0"
 end

--- a/rt_rubocop_defaults.gemspec
+++ b/rt_rubocop_defaults.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.description   = "rubocop defaults used at runtastic"
   spec.license       = "MIT"
   spec.homepage      = "https://github.com/runtastic/rt_rubocop_defaults"
-  spec.required_ruby_version = "~> 2.3"
+  spec.required_ruby_version = "~> 2.4"
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
@@ -22,7 +22,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.81.0"
+  spec.add_dependency "rubocop", "~> 0.88"
   spec.add_development_dependency "bundler", "> 1.13", "< 3"
+  spec.add_development_dependency "mry"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
remove old config
enable all new cops (since ~0.79)
make ruby 2.4+