### PR TITLE
Allow verify from approvals gem as the only expectation in a test

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -152,3 +152,7 @@ RSpec/NestedGroups:
 
 RSpec/MultipleMemoizedHelpers:
   Enabled: false
+
+RSpec/NoExpectationExample:
+  AllowedPatterns:
+    - 'verify'


### PR DESCRIPTION
When we are using the approvals gem we sometimes only have `verify` in the tests themselves. This should be a valid expectation and to achieve this we need to add it to the allowed patterns