### PR TITLE
Fix add missing dependency

### DIFF
--- a/lib/rt_rubocop_defaults/version.rb
+++ b/lib/rt_rubocop_defaults/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RTRuboCopDefaults
-  VERSION = "2.8.0"
+  VERSION = "2.8.1"
 end

--- a/rt_rubocop_defaults.gemspec
+++ b/rt_rubocop_defaults.gemspec
@@ -25,4 +25,6 @@ Gem::Specification.new do |spec|
   spec.metadata["rubygems_mfa_required"] = "true"
 
   spec.add_dependency "rubocop", "~> 1.61"
+  # HINT: Needed as long as the `RSpec::UnexpectedRequires` cop is part of this repo
+  spec.add_dependency "rubocop-rspec", "~> 3.1"
 end


### PR DESCRIPTION
The previous PR (https://github.com/runtastic/rt_rubocop_defaults/pull/24) added the `UnexpectedRequires` cop, but missed to add the dependency for `rubocop-rspec`.

This PR adds the dependency.